### PR TITLE
read from the client-side socket

### DIFF
--- a/providers/socket.js
+++ b/providers/socket.js
@@ -141,7 +141,7 @@ Socket_chrome.prototype.listen = function(socketId, address, port, callback) {
           clientSocketId: acceptInfo.socketId
         });
         chrome.socket.accept(sid, acceptCallback);
-        this.read(sid);
+        this.read(acceptInfo.socketId);
       // -15 is socket_not_connected.
       } else if (acceptInfo.resultCode !== -15) {
         console.warn('Failed to accept on ' + sid + ': ' +


### PR DESCRIPTION
This fixes a bug whereby the accept loop invokes the read loop with the server-side socket rather than the _client-side_ socket. Reads were being dropped on the floor.

Not sure how this happened and it was tricky to track down because the error didn't appear in the (main) JavaScript console :-/

Tested by hacking socks-rtc's TcpEchoServer into its Chrome extension and eyeballing the telnet output:
https://github.com/uProxy/socks-rtc/compare/yangoon-echo-server-test
