### PR TITLE
fixed ^ and ~ use for freedom, and fixed es5-shim warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
   "devDependencies": {
     "async": "^0.9.0",
     "chalk": "^0.4.0",
-    "es5-shim": "^3.3.2",
+    "es5-shim": "^4.0.0",
     "es6-promise": "^1.0.0",
-    "freedom": "^0.5.2",
+    "freedom": "~0.5.2",
     "fs-extra": "^0.10.0",
     "glob": "^4.0.2",
     "grunt": "^0.4.5",
@@ -39,7 +39,7 @@
     "wd": "^0.3.0"
   },
   "peerDependencies": {
-    "freedom": "^0.5.0"
+    "freedom": "~0.5.0"
   },
   "scripts": {}
 }


### PR DESCRIPTION
Fixes https://github.com/freedomjs/freedom-for-chrome/issues/18

TESTED: 
grunt
