### PR TITLE
bump version number for udp receive fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "freedom-for-chrome",
   "description": "Embracing a distributed web",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "homepage": "http://freedomjs.org",
   "bugs": {
     "url": "http://github.com/freedomjs/freedom-for-chrome/issues",


### PR DESCRIPTION
Bump version number for republishing NPM for this fix:
https://github.com/freedomjs/freedom-for-chrome/pull/20

(sorry, forgot to change this in the original change)
