### PR TITLE
return an error rather than false so grunt exits with non-zero status

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "freedom-for-chrome",
   "description": "Embracing a distributed web",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "homepage": "http://freedomjs.org",
   "bugs": {
     "url": "http://github.com/freedomjs/freedom-for-chrome/issues",

--- a/tasks/integration.js
+++ b/tasks/integration.js
@@ -226,7 +226,7 @@ module.exports = function (grunt) {
       good = false;
     }
     if (ctx.keepBrowser) {
-      return next(good);
+      return next(good || new Error('One or more tests failed.'));
     }
 
     fs.removeSync(ctx.dir);
@@ -236,7 +236,7 @@ module.exports = function (grunt) {
       ctx.server && ctx.server.kill();
     }, 500);
     setTimeout(function() {
-      next(good);
+      next(good || new Error('One or more tests failed.'));
     }, 1000);
   }
 };


### PR DESCRIPTION
Right now, grunt (and therefore Jenkins) thinks our tests have passed even when they've failed, so long as all the tests run.

Skimming the docs for async, it seems you need to invoke the callback with an `Error`.