### PR TITLE
fix errcode typo in tcpsocket provider, fixing ondisconnect events

### DIFF
--- a/providers/core.tcpsocket.js
+++ b/providers/core.tcpsocket.js
@@ -320,7 +320,7 @@ Socket_chrome.prototype.dispatchDisconnect = function (code) {
   }
 
   var errorObject = {
-    'errorcode': freedomErrorCode,
+    'errcode': freedomErrorCode,
     'message': errorMessage
   };
 


### PR DESCRIPTION
This crept in with this pull request:
https://github.com/freedomjs/freedom-for-chrome/pull/59

Please note that I see a failure with the `core.tcpsocket Gives error when connecting to invalid domain` test case with and without this change.