### PR TITLE
core.tcpsocket.send callback should check chrome.runtime.lasterror

### DIFF
--- a/providers/core.tcpsocket.js
+++ b/providers/core.tcpsocket.js
@@ -207,6 +207,15 @@ Socket_chrome.prototype.write = function(data, cb) {
   }
 
   chrome.sockets.tcp.send(this.id, data, function(sendInfo) {
+    // This will happen when the send callback is invoked after the socket
+    // has closed but before the dispatchDisconnect has been invoked.
+    if (chrome.runtime.lastError) {
+      this.dispatchDisconnect();
+      return cb(undefined, {
+        'errcode': 'NOT_CONNECTED',
+        'message': 'Cannot Write on Closed Socket'
+      });
+    }
     if (sendInfo.resultCode < 0) {
       var errorObject = this.dispatchDisconnect(sendInfo.resultCode);
       return cb(undefined, {

--- a/spec/tcpsocket.unit.spec.js
+++ b/spec/tcpsocket.unit.spec.js
@@ -61,6 +61,9 @@ describe("tcpsocket", function() {
             removeListener: function() {}
           }
         }
+      },
+      runtime: {
+        lastError: undefined
       }
     };
 


### PR DESCRIPTION
We are on a logging drive right now and in certain cases the SOCKS proxy is encountering this `chrome.runtime.lastError` on send.

This allows us log the error in detail.

There may be other methods in here which should check `chrome.runtime.lastError` but I haven't had the need to dive into that.