### PR TITLE
core.tcpsocket.getInfo should check chrome.runtime.lastError

### DIFF
--- a/providers/core.tcpsocket.js
+++ b/providers/core.tcpsocket.js
@@ -39,7 +39,17 @@ Socket_chrome.prototype.getInfo = function(continuation) {
   if (this.id) {
     // Note: this.namespace used, since this method is common to tcp and
     // tcpServer sockets.
-    this.namespace.getInfo(this.id, continuation);
+    this.namespace.getInfo(this.id, function(info) {
+      // This can happen if the socket is disconnected
+      // before the callback is invoked.
+      if (chrome.runtime.lastError) {
+        continuation({
+          connected: false
+        });
+      } else {
+        continuation(info);
+      }
+    });
   } else {
     continuation({
       connected: false


### PR DESCRIPTION
I've seen this crop up once or twice in the logs when I've been running the proxy for a long time:
https://github.com/uProxy/uproxy/issues/943

Basically same as:
https://github.com/freedomjs/freedom-for-chrome/pull/69