### PR TITLE
Add support for the new pause() and resume() methods in core.tcpsocket.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "es5-shim": "^4.0.0",
     "es6-promise": "^2.0.0",
     "folderify": "^0.6.0",
-    "freedom": "~0.6.19",
+    "freedom": "~0.6.21",
     "grunt": "^0.4.5",
     "grunt-browserify": "^3.2.1",
     "grunt-bump": "0.0.16",
@@ -45,7 +45,7 @@
     "webrtc-adapter": "~0.0.6"
   },
   "peerDependencies": {
-    "freedom": "~0.6.19"
+    "freedom": "~0.6.21"
   },
   "scripts": {}
 }

--- a/providers/core.tcpsocket.js
+++ b/providers/core.tcpsocket.js
@@ -137,7 +137,8 @@ Socket_chrome.prototype.secure = function(cb) {
       if (error) {
         cb(undefined, {
           'errcode': 'CONNECTION_FAILED',
-          'message': 'Secure failed: error unpausing socket'
+          'message': 'Secure failed: error unpausing socket: ' +
+              error['message']
         });
         return;
       }
@@ -165,7 +166,8 @@ Socket_chrome.prototype.prepareSecure = function(cb) {
     if (error) {
       cb(undefined, {
         'errcode': 'CONNECTION_FAILED',
-        'message': 'prepareSecure failed: error pausing socket'
+        'message': 'prepareSecure failed: error pausing socket: ' +
+            error['message']
       });
       return;
     }


### PR DESCRIPTION
This depends on a recent change to freedom, which has not yet been released as a new version.