### PR TITLE
Changing buffer size to 16K.

### DIFF
--- a/providers/core.tcpsocket.js
+++ b/providers/core.tcpsocket.js
@@ -72,7 +72,7 @@ Socket_chrome.prototype.connect = function(hostname, port, cb) {
     });
     return;
   }
-  chrome.sockets.tcp.create({}, function(createInfo) {
+  chrome.sockets.tcp.create({'bufferSize' : 1024 * 16}, function(createInfo) {
     this.id = createInfo.socketId;
     try {
       chrome.sockets.tcp.connect(this.id, hostname, port, function(result) {


### PR DESCRIPTION
The default Chrome buffer size is 4K, which causes more packet events for the uProxy Churn module. Increasing this size to 16K makes it roughly 13% faster. This handles the 15K DataChannel chunks in one go.

In an ideal world, I would want to make this configurable and set the two properties from one place, passing them in to freedom. But it seems like that is worth a fuller exploration of what properties in freedom should be configurable.