### PR TITLE
Use a more tolerant self-loading URL procedure.

### DIFF
--- a/lib/entry.js
+++ b/lib/entry.js
@@ -21,7 +21,7 @@ var findSrc = function(doc) {
   // before (and after) freedom-for-chrome.
   var tags = doc.getElementsByTagName('script');
   for (var i = 0; i < tags.length; ++i) {
-    if (tags[i].src.indexOf('freedom-for-chrome') != -1) {
+    if (tags[i].src.indexOf('freedom-for-chrome') !== -1) {
       return tags[i].src;
     }
   }

--- a/lib/entry.js
+++ b/lib/entry.js
@@ -14,11 +14,25 @@ var providers = [
   require('freedom/providers/core/core.xhr')
 ];
 
+var findSrc = function(doc) {
+  // The script tag that loads freedom can be in the header (in some manually
+  // created background pages) or in the body (as in the case of automatically
+  // created background pages.  There may also be other scripts loaded
+  // before (and after) freedom-for-chrome.
+  var tags = doc.getElementsByTagName('script');
+  for (var i = 0; i < tags.length; ++i) {
+    if (tags[i].src.indexOf('freedom-for-chrome') != -1) {
+      return tags[i].src;
+    }
+  }
+  throw new Error('No script tag for freedom-for-chrome!');
+};
+
 if (typeof window !== 'undefined') {
   window.freedom = require('freedom/src/entry').bind({}, {
     location: window.location.href,
     portType: require('freedom/src/link/worker'),
-    source: window.document.head.lastChild.src,
+    source: findSrc(window.document),
     providers: providers,
     oauth: [
       require('../providers/oauth/oauth.identity'),


### PR DESCRIPTION
All tests pass.