### PR TITLE
Close sockets on disconnect.

### DIFF
--- a/providers/core.tcpsocket.js
+++ b/providers/core.tcpsocket.js
@@ -414,6 +414,9 @@ Socket_chrome.prototype.dispatchDisconnect = function (code) {
 
   // Don't send more than one dispatchDisconnect event.
   if (this.hasId()) {
+    // Every socket must be explicitly closed, even if it has already been
+    // disconnected, to avoid a memory leak.
+    this.namespace.close(this.id, function() {});
     Socket_chrome.removeActive(this.id);
     delete this.id;
 

--- a/spec/tcpsocket.unit.spec.js
+++ b/spec/tcpsocket.unit.spec.js
@@ -43,6 +43,9 @@ describe("tcpsocket", function() {
           onReceiveError: {
             addListener: function() {},
             removeListener: function() {}
+          },
+          close: function(socketId, callback) {
+            callback();
           }
         },
         tcpServer: {
@@ -59,6 +62,9 @@ describe("tcpsocket", function() {
           onAcceptError: {
             addListener: function() {},
             removeListener: function() {}
+          },
+          close: function(socketId, callback) {
+            callback();
           }
         }
       },


### PR DESCRIPTION
This allows the browser to free its socket object.

Fixes https://github.com/uProxy/uproxy/issues/2443